### PR TITLE
fix a typo in tag for empire

### DIFF
--- a/English/semantic_lexicon_en.tsv
+++ b/English/semantic_lexicon_en.tsv
@@ -24875,7 +24875,7 @@ emphasized	VERB	A11.1+
 emphatic	ADJ	E6+
 emphatically	ADV	E6+
 emphysema	NOUN	B2-
-empire	NOUN	G1.1 I2.1/S+
+empire	NOUN	G1.1 I2.1/S7.1+
 empire-building	NOUN	S7.1+
 empirical	ADJ	X2.4
 employ	VERB	I3.1 A1.5.1


### PR DESCRIPTION
"empire" had a typo in its semantic tag, replaced with a category that exists in the tagset